### PR TITLE
[Bug: #163916837] Signup password match

### DIFF
--- a/src/app/signup/SignupComponent.jsx
+++ b/src/app/signup/SignupComponent.jsx
@@ -19,6 +19,11 @@ const SignupComponent = ({ signupUser, signupState, errorMessage }) => {
     const userEmail = e.target.elements.email.value.trim();
     const name = e.target.elements.username.value.trim();
     const password = e.target.elements.password.value.trim();
+    const rePassword = e.target.elements.rePassword.value.trim();
+    if (password !== rePassword) {
+      e.target.elements.rePassword.setCustomValidity('Passwords must match');
+      return;
+    }
     signupUser(userEmail, name, password);
   };
 
@@ -77,6 +82,8 @@ const SignupComponent = ({ signupUser, signupState, errorMessage }) => {
               type="text"
               name="username"
               placeholder="Username"
+              pattern=".{6,}"
+              title="Username must be at least 6 characters"
               required
             />
           </div>
@@ -90,6 +97,8 @@ const SignupComponent = ({ signupUser, signupState, errorMessage }) => {
               name="password"
               id="password"
               placeholder="Password"
+              pattern=".{6,}"
+              title="Password must be at least 8 characters"
               required
             />
           </div>

--- a/src/app/signup/signup.test.js
+++ b/src/app/signup/signup.test.js
@@ -55,7 +55,30 @@ describe('SIGNUP TEST SUITE', () => {
             username: { value: 'johndoe' },
             email: { value: 'johndoe@joe.com' },
             password: { value: 'johndoe88' },
-            rePassword: { value: '' },
+            rePassword: { value: '', setCustomValidity: () => {} },
+          },
+        },
+      });
+      expect(signupUser).not.toHaveBeenCalled();
+    });
+
+    it('it should not submit the form if passwords do not match', () => {
+      const signupUser = jest.fn();
+      const props = {
+        signupUser,
+        signupState: '',
+        errorMessage: 'Email password username',
+        history: {},
+      };
+      const component = shallow(<SignupComponent {...props} />);
+      component.find('form').simulate('submit', {
+        preventDefault: () => {},
+        target: {
+          elements: {
+            username: { value: 'johndoe' },
+            email: { value: 'johndoe@joe.com' },
+            password: { value: 'johndoe88' },
+            rePassword: { value: 'john8doe', setCustomValidity: () => {} },
           },
         },
       });
@@ -78,7 +101,7 @@ describe('SIGNUP TEST SUITE', () => {
             username: { value: 'johndoe' },
             email: { value: 'johndoe@joe.com' },
             password: { value: 'johndoe88' },
-            rePassword: { value: 'johndoe88' },
+            rePassword: { value: 'johndoe88', setCustomValidity: () => {} },
           },
         },
       });
@@ -138,7 +161,7 @@ describe('SIGNUP TEST SUITE', () => {
             username: { value: 'johndoe' },
             email: { value: 'johndoe@joe.com' },
             password: { value: 'johndoe88' },
-            rePassword: { value: '' },
+            rePassword: { value: 'johndoe88', setCustomValidity: () => {} },
           },
         },
       });
@@ -180,7 +203,7 @@ describe('SIGNUP TEST SUITE', () => {
             username: { value: 'johndoe' },
             email: { value: 'johndoe@joe.com' },
             password: { value: 'johndoe88' },
-            rePassword: { value: '' },
+            rePassword: { value: 'johndoe88', setCustomValidity: () => {} },
           },
         },
       });


### PR DESCRIPTION
#### What does this PR do?
- It ensures passwords must match before signup form can be submitted

#### Description of Task to be completed?
- [x] add a validator that checks if passwords match when a user submits signup form

#### How should this be manually tested?
- [x] goto '/signup' and try to submit the form without putting matching passwords

#### What are the relevant pivotal tracker stories?
- [#163916837](https://www.pivotaltracker.com/story/show/163916837)


